### PR TITLE
Cleaned Up and Refactored Existing Component Tests

### DIFF
--- a/components/application/Navigation.spec.tsx
+++ b/components/application/Navigation.spec.tsx
@@ -5,11 +5,11 @@ import {
   render
 } from "@testing-library/react"
 
+import Navigation from "./Navigation"
+
 const useRouter = jest.spyOn(require("next/router"), "useRouter")
 const UserPicker = jest.spyOn(require("../users/UserPicker"), "default")
 const UserPickerText = "<UserPicker/>"
-
-import Navigation from "./Navigation"
 
 describe("<Navigation/>", () => {
   it("should render", () => {

--- a/components/users/UserDetails.spec.tsx
+++ b/components/users/UserDetails.spec.tsx
@@ -5,6 +5,7 @@ import {
   render
 } from "@testing-library/react"
 
+import UserDetails from "./UserDetails"
 import {
   User
 } from "../../features/users"
@@ -15,8 +16,6 @@ const user: User = {
   title: "Test User in Test",
   notes: "John Smith is a test user in test."
 }
-
-import UserDetails from "./UserDetails"
 
 describe("<UserDetails/>", () => {
   it("should render the user details properly", () => {

--- a/components/users/UsersList.spec.tsx
+++ b/components/users/UsersList.spec.tsx
@@ -6,6 +6,7 @@ import {
   render
 } from "@testing-library/react"
 
+import UsersList from "./UsersList"
 import {
   User
 } from "../../features/users"
@@ -24,11 +25,9 @@ const jane: User = {
   notes: "Jane Smith is a test user in test."
 }
 
-import UsersList from "./UsersList"
-
 describe("<UsersList/>", () => {
   it("should render the user details properly", () => {
-    const {getByText, getAllByRole} = render(
+    const {getByText} = render(
       <UsersList users={[john, jane]} user={john} getUrl={id => id.toString(10)}/>
     )
     expect(getByText(john.name)).toBeInTheDocument()


### PR DESCRIPTION
Existing component tests (especially users) had a few situations where mocks were used, when the appropriate hooks could be exercised instead, and a common test component could be factored to handle each test case in a more parameterized fashion.

Signed-off-by: Jonah Grimes <jgrimes@appriss.com>